### PR TITLE
Significantly optimize performance

### DIFF
--- a/estimator.go
+++ b/estimator.go
@@ -34,75 +34,111 @@ const (
 //
 // For more info: https://en.wikipedia.org/wiki/Count%E2%80%93min_sketch
 type Estimator[K comparable] struct {
-	data []hashSlots
-}
-
-type hashSlots struct {
-	seed  maphash.Seed
-	slots []atomic.Int64
+	rows, columns int
+	seed1, seed2  maphash.Seed
+	data          []atomic.Int64
 }
 
 // NewEstimator returns a new Estimator instance using the default hash and slot
 // sizes.
-func NewEstimator[K comparable]() Estimator[K] {
+func NewEstimator[K comparable]() *Estimator[K] {
 	return NewEstimatorWithSize[K](DefaultHashes, DefaultSlots)
 }
 
 // NewEstimatorWithSize returns a new Estimator instance using the provided
 // number of hashes and slots. This function panics if hashes or slots are less
-// than or equal to zero.
-func NewEstimatorWithSize[K comparable](hashes, slots int) Estimator[K] {
+// than or equal to zero, or hashes is greater than 64. The number of slots is
+// rounded up to the nearest power of 2.
+func NewEstimatorWithSize[K comparable](hashes, slots int) *Estimator[K] {
 	if hashes <= 0 {
 		panic("limits: hashes must be greater than 0")
+	}
+	if hashes > 64 {
+		panic("limits: hashes must be less than or equal to 64")
 	}
 	if slots <= 0 {
 		panic("limits: slots must be greater than 0")
 	}
 
-	data := make([]hashSlots, hashes)
-	for i := range data {
-		data[i] = hashSlots{
-			seed:  maphash.MakeSeed(),
-			slots: make([]atomic.Int64, slots),
-		}
-	}
+	slots = int(roundUpPow2(uint64(slots)))
+	data := make([]atomic.Int64, hashes*slots)
+	seed1 := maphash.MakeSeed()
+	seed2 := maphash.MakeSeed()
 
-	return Estimator[K]{data}
+	return &Estimator[K]{hashes, slots, seed1, seed2, data}
 }
 
 // Get returns the estimated count for the provided key.
-func (e Estimator[K]) Get(key K) int64 {
-	var minimum int64 = math.MaxInt64
-	for _, hs := range e.data {
-		hash := maphash.Comparable(hs.seed, key)
-		count := hs.slots[int(hash%uint64(len(hs.slots)))].Load()
+func (e *Estimator[K]) Get(key K) int64 {
+	h1, h2 := maphash.Comparable(e.seed1, key), maphash.Comparable(e.seed2, key)
+
+	minimum := int64(math.MaxInt64)
+	for i := 0; i < e.rows; i++ {
+		index := e.index(h1, h2, i)
+		count := e.data[i*e.columns+index].Load()
 		minimum = min(minimum, count)
 	}
 	return minimum
 }
 
 // Incr is the equivalent of calling `IncrN(key, 1)`.
-func (e Estimator[K]) Incr(key K) int64 {
+func (e *Estimator[K]) Incr(key K) int64 {
 	return e.IncrN(key, 1)
 }
 
 // IncrN increments the count by 'n' for the provided key, returning the
 // estimated total count.
-func (e Estimator[K]) IncrN(key K, n int64) int64 {
-	var minimum int64 = math.MaxInt64
-	for _, hs := range e.data {
-		hash := maphash.Comparable(hs.seed, key)
-		count := hs.slots[int(hash%uint64(len(hs.slots)))].Add(n)
-		minimum = min(minimum, count)
+func (e *Estimator[K]) IncrN(key K, n int64) int64 {
+	h1, h2 := maphash.Comparable(e.seed1, key), maphash.Comparable(e.seed2, key)
+
+	// First pass: get rows that match the minimum.
+	var mask uint64
+	minimum := int64(math.MaxInt64)
+	for i := range e.rows {
+		index := e.index(h1, h2, i)
+		count := e.data[i*e.columns+index].Load()
+		if count < minimum {
+			minimum = count
+			mask = 1 << uint64(i)
+		} else if count == minimum {
+			mask |= 1 << uint64(i)
+		}
 	}
+
+	// Second pass: increment only the rows that matched the minimum.
+	minimum = math.MaxInt64
+	for i := range e.rows {
+		if (mask>>uint(i))&1 == 1 {
+			index := e.index(h1, h2, i)
+			count := e.data[i*e.columns+index].Add(n)
+			minimum = min(minimum, count)
+		}
+	}
+
 	return minimum
 }
 
 // Reset clears the Estimator, returning all counts to 0.
-func (e Estimator[K]) Reset() {
-	for _, hs := range e.data {
-		for i := range hs.slots {
-			hs.slots[i].Store(0)
-		}
+func (e *Estimator[K]) Reset() {
+	for i := range e.data {
+		e.data[i].Store(0)
 	}
+}
+
+func (e *Estimator[K]) index(h1, h2 uint64, row int) int {
+	return int((h1 + uint64(row)*h2) & uint64(e.columns-1))
+}
+
+func roundUpPow2(x uint64) uint64 {
+	if x <= 1 {
+		return 1
+	}
+	x--
+	x |= x >> 1
+	x |= x >> 2
+	x |= x >> 4
+	x |= x >> 8
+	x |= x >> 16
+	x |= x >> 32
+	return x + 1
 }

--- a/estimator_test.go
+++ b/estimator_test.go
@@ -7,9 +7,7 @@ func TestEstimator(t *testing.T) {
 		key1 = "one"
 		key2 = "two"
 	)
-
 	est := NewEstimator[string]()
-
 	v := est.Incr(key1)
 	assertIntsEqual(t, v, 1)
 	v = est.Incr(key2)
@@ -44,25 +42,43 @@ func assertIntsEqual(t *testing.T, got, exp int64) {
 	}
 }
 
-func BenchmarkEstimatorGetString(b *testing.B) {
+func BenchmarkEstimatorGetStringSmall(b *testing.B) {
 	e := NewEstimatorWithSize[string](4, 1024)
-
 	for b.Loop() {
 		e.Get("a")
 	}
 }
 
-func BenchmarkEstimatorIncrString(b *testing.B) {
+func BenchmarkEstimatorIncrStringSmall(b *testing.B) {
 	e := NewEstimatorWithSize[string](4, 1024)
-
 	for b.Loop() {
 		e.Incr("a")
 	}
 }
 
-func BenchmarkEstimatorReset(b *testing.B) {
+func BenchmarkEstimatorResetSmall(b *testing.B) {
 	e := NewEstimatorWithSize[string](4, 1024)
+	for b.Loop() {
+		e.Reset()
+	}
+}
 
+func BenchmarkEstimatorGetStringLarge(b *testing.B) {
+	e := NewEstimatorWithSize[string](8, 8192)
+	for b.Loop() {
+		e.Get("a")
+	}
+}
+
+func BenchmarkEstimatorIncrStringLarge(b *testing.B) {
+	e := NewEstimatorWithSize[string](8, 8192)
+	for b.Loop() {
+		e.Incr("a")
+	}
+}
+
+func BenchmarkEstimatorResetLarge(b *testing.B) {
+	e := NewEstimatorWithSize[string](8, 8192)
 	for b.Loop() {
 		e.Reset()
 	}

--- a/rate.go
+++ b/rate.go
@@ -32,7 +32,7 @@ const (
 // A Rate instance is lock-free, but is safe to use concurrency from multiple
 // goroutines.
 type Rate[K comparable] struct {
-	red, blue       Estimator[K]
+	red, blue       *Estimator[K]
 	isRed           atomic.Bool
 	start           time.Time
 	resetIntervalMs int64
@@ -107,7 +107,7 @@ func (r *Rate[K]) maybeReset() int64 {
 	return pastMs
 }
 
-func (r *Rate[K]) getEstimator(isRed bool) Estimator[K] {
+func (r *Rate[K]) getEstimator(isRed bool) *Estimator[K] {
 	if isRed {
 		return r.red
 	}

--- a/rate_test.go
+++ b/rate_test.go
@@ -38,12 +38,12 @@ func TestRateConcurrency(t *testing.T) {
 	r := NewRate[string](time.Second)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			key := strconv.Itoa(i + 1)
-			for j := 0; j < 1000; j++ {
+			for j := range 1000 {
 				v := r.Observe(key)
 				if v != int64(j+1) {
 					panic(fmt.Sprintf("unexpected value: %d", v))
@@ -53,7 +53,7 @@ func TestRateConcurrency(t *testing.T) {
 	}
 	wg.Wait()
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		key := strconv.Itoa(i + 1)
 		if v := r.Observe(key); v != 1001 {
 			t.Fatalf("unexpected value: %v", v)
@@ -63,16 +63,14 @@ func TestRateConcurrency(t *testing.T) {
 
 func BenchmarkRateGetString(b *testing.B) {
 	r := NewRate[string](time.Second)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		r.Get("a")
 	}
 }
 
 func BenchmarkRateObserveString(b *testing.B) {
 	r := NewRate[string](time.Second)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		r.Observe("a")
 	}
 }


### PR DESCRIPTION
This PR adds the following enhancements to the `Estimator`:
- makes the slots field a single continuous slice of atomic values
- uses a "double hashing" technique to significantly reduce the amount of hashing required
- rounds the number of slots up to the next power of 2 for more efficiency
- modifies the `Incr` methods to use a more conservative approach to incrementing that increases accuracy substantially for "zipf" style distributions. It also appears to actually increase performance under high contention.